### PR TITLE
Fix bug in flap

### DIFF
--- a/src/prog/voiceWarning.java
+++ b/src/prog/voiceWarning.java
@@ -257,7 +257,7 @@ public class voiceWarning implements Runnable {
 		st = xS.sState;
 		indic = xS.sIndic;
 		// 加载其他
-		aoaCrit = new audClip("./voice/aoaCrit.wav", 2);
+		aoaCrit = new audClip("./voice/aoaCrit.wav", 1);
 		aoaHigh = new audClip("./voice/aoaHigh.wav", 8);
 		aoaWarningLine = 15;
 		if (xc.blkx != null && xc.blkx.valid)
@@ -268,9 +268,9 @@ public class voiceWarning implements Runnable {
 		aileronEffIAS = 65535;
 		int lowEff = 20;
 		if (xc.blkx != null && xc.blkx.valid) {
-			rudderEffIAS = (int) (xc.blkx.rudderEff + 200);
-			elevatorEffIAS = (int) (xc.blkx.elavEff + 200);
-			aileronEffIAS = (int) (xc.blkx.aileronEff + 200);
+			rudderEffIAS = (int) (xc.blkx.rudderEff);
+			elevatorEffIAS = (int) (xc.blkx.elavEff);
+			aileronEffIAS = (int) (xc.blkx.aileronEff);
 		}
 
 		rudderEff = new audClip("./voice/rudderEff.wav", 10);
@@ -282,7 +282,7 @@ public class voiceWarning implements Runnable {
 		rpmHighWarn = new audClip("./voice/warn_highrpm.wav", 10);
 
 		// 襟翼
-		flapWarn = new audClip("./voice/warn_flap.wav", 5);
+		flapWarn = new audClip("./voice/warn_flap.wav", 1);
 
 		// 失速
 		speedWarningLine = 0;
@@ -459,7 +459,7 @@ public class voiceWarning implements Runnable {
 			// 襟翼判断逻辑
 			// 先得判断襟翼在哪个段内
 			// 使用线性方式获得襟翼的限速
-			if (isFlapAlive && st.IAS >= xS.flapAllowSpeed * 0.95f) {
+			if (isFlapAlive && xS.flapAllowAngle - st.flaps < 8 && st.flaps > 1) {
 				fatal = true;
 				flapWarn.playOnce(t);
 			}


### PR DESCRIPTION
1：修改襟翼档位判断函数bug，使整个襟翼插值函数可以被正常启动
2：按issue修改插值函数的定义域与值域，输入ias输出当前状态的极限襟翼开度；同时为了后续工作的方便，这个函数值域为0~125。
3：修改襟翼语音告警逻辑，当当前襟翼开度小于襟翼极限开度-8时报警
4：修改两个时敏语音告警的cold time，aoaCrit与Warning——flap更改至1s
5：修改锁舵语音告警逻辑，现在从开始锁舵时就会报警
TODO：
1：minihud上可视化襟翼极限与当前开度，由于没看懂minihud那个画线以及各个数字的位置是怎么排的所以没写，但写起来类似于机动性指标线|   -|----|--- |    |，大概长这样
2：襟翼语音告警逻辑其实并不太好，比较良好的写法是两边求导，然后算相遇时间，但是并没良好get到代码结构和数据帧时长的相关变量，所以先用-8这样的逻辑
3：把auto_flap融合进voidmei，这需要voidmei有一个没有冷却时间的快速脉冲专门给这个组件。鉴于voidmei复杂的结构，可能会在[auto_flap](https://github.com/tu10ng/autoflap)里轻量化的实现，届时可以自动控制几乎所有飞机的襟翼为临界值……